### PR TITLE
support multiple invocations of the same option

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = (optstring, args = process.argv.slice(2)) => {
     for(let i = 0, l = optstring.length; i < l; i++){
         if(optstring[i + 1] === ':'){
             result[optstring[i]] = '';
+            result[`_${optstring[i]}`] = [];
             i++;
         } else {
             result[optstring[i]] = 0;
@@ -40,11 +41,13 @@ module.exports = (optstring, args = process.argv.slice(2)) => {
             if(typeof result[c] === 'string'){
                 if(opts.length > 0){
                     result[c] = opts.join('');
+                    result[`_${c}`].push(opts.join(''));
                     break;
                 } else if(args[i + 1] === undefined){
                     throw new Error(`option ${c} needs argument`);
                 } else {
                     result[c] = args[i + 1];
+                    result[`_${c}`].push(args[i + 1]);
                     i++;
                 }
             }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = (optstring, args = process.argv.slice(2)) => {
             result[optstring[i]] = '';
             i++;
         } else {
-            result[optstring[i]] = false;
+            result[optstring[i]] = 0;
         }
     }
 
@@ -36,7 +36,7 @@ module.exports = (optstring, args = process.argv.slice(2)) => {
         let c = opts.shift();
         while(c !== undefined){
             if(typeof result[c] === 'undefined') throw new Error(`illegal option -- ${c}`);
-            if(typeof result[c] === 'boolean') result[c] = true;
+            if(typeof result[c] === 'number') result[c]++;
             if(typeof result[c] === 'string'){
                 if(opts.length > 0){
                     result[c] = opts.join('');

--- a/test.js
+++ b/test.js
@@ -85,7 +85,7 @@ test('options', t => {
 
     t.deepEqual(
         oopt('a:1:', []),
-        {a: '', 1: ''},
+        {a: '', 1: '', _a: [], _1: []},
         'options with arguments'
     );
 });
@@ -117,73 +117,79 @@ test('values', t => {
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b arg')),
-        {a: 1, b: 'arg', c: 0},
+        {a: 1, b: 'arg', c: 0, _b: ['arg']},
         'options with no operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('--')),
-        {a: 0, b: '', c: 0, _: []},
+        {a: 0, b: '', c: 0, _b: [], _: []},
         '-- is no option'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-ab arg p1 p2')),
-        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _b: ['arg'], _: ['p1', 'p2']},
         'grouped options with argument and operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b arg p1 p2')),
-        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _b: ['arg'], _: ['p1', 'p2']},
         'separate options with argument and operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-b arg -a p1 p2')),
-        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _b: ['arg'], _: ['p1', 'p2']},
         'options order does not matter'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -barg p1 p2')),
-        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _b: ['arg'], _: ['p1', 'p2']},
         'argument joined with option'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-abarg p1 p2')),
-        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _b: ['arg'], _: ['p1', 'p2']},
         'argument joined with group options'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b arg -- -c p1 -p2')),
-        {a: 1, b: 'arg', c: 0, _: ['-c', 'p1', '-p2']},
+        {a: 1, b: 'arg', c: 0, _b: ['arg'], _: ['-c', 'p1', '-p2']},
         'everything after "--" there is operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b "a r g" "p1 p2"')),
-        {a: 1, b: 'a r g', c: 0, _: ['p1 p2']},
+        {a: 1, b: 'a r g', c: 0, _b: ['a r g'], _: ['p1 p2']},
         'multiword operands and argument'
     );
 
     t.deepEqual(
+        oopt('ab:c', arrgv('-a -b a -b r -b g "p1 p2"')),
+        {a: 1, b: 'g', c: 0, _b: ['a', 'r', 'g'], _: ['p1 p2']},
+        'multiple invocations of one option with different arguments'
+    );
+
+    t.deepEqual(
         oopt('ab:c', arrgv('-b -a')),
-        {a: 0, b: '-a', c: 0},
+        {a: 0, b: '-a', c: 0, _b: ['-a']},
         'no optional arguments'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('"-a -b"')),
-        {a: 0, b: '', c: 0, _: ['-a -b']},
+        {a: 0, b: '', c: 0, _b: [], _: ['-a -b']},
         'no multiword options'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('p1 p2 -a -b arg')),
-        {a: 0, b: '', c: 0, _: ['p1', 'p2', '-a', '-b', 'arg']},
+        {a: 0, b: '', c: 0, _b: [], _: ['p1', 'p2', '-a', '-b', 'arg']},
         'operands before options'
     );
 

--- a/test.js
+++ b/test.js
@@ -67,19 +67,19 @@ test('options', t => {
 
     t.deepEqual(
         oopt('a', []),
-        {a: false},
+        {a: 0},
         'small letter in optstring'
     );
 
     t.deepEqual(
         oopt('A', []),
-        {A: false},
+        {A: 0},
         'capital letter in optstring'
     );
 
     t.deepEqual(
         oopt('1', []),
-        {1: false},
+        {1: 0},
         'digit in optstring'
     );
 
@@ -93,85 +93,97 @@ test('options', t => {
 test('values', t => {
     t.deepEqual(
         oopt('a', arrgv('-a')),
-        {a: true},
+        {a: 1},
         'single option'
     );
 
     t.deepEqual(
+        oopt('a', arrgv('-a -a')),
+        {a: 2},
+        'single option multiple invocations'
+    );
+
+    t.deepEqual(
+        oopt('a', arrgv('-aa')),
+        {a: 2},
+        'single option multiple invocations grouped'
+    );
+
+    t.deepEqual(
         oopt('a', arrgv('"-a"')),
-        {a: true},
+        {a: 1},
         'quoted single option'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b arg')),
-        {a: true, b: 'arg', c: false},
+        {a: 1, b: 'arg', c: 0},
         'options with no operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('--')),
-        {a: false, b: '', c: false, _: []},
+        {a: 0, b: '', c: 0, _: []},
         '-- is no option'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-ab arg p1 p2')),
-        {a: true, b: 'arg', c: false, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
         'grouped options with argument and operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b arg p1 p2')),
-        {a: true, b: 'arg', c: false, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
         'separate options with argument and operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-b arg -a p1 p2')),
-        {a: true, b: 'arg', c: false, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
         'options order does not matter'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -barg p1 p2')),
-        {a: true, b: 'arg', c: false, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
         'argument joined with option'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-abarg p1 p2')),
-        {a: true, b: 'arg', c: false, _: ['p1', 'p2']},
+        {a: 1, b: 'arg', c: 0, _: ['p1', 'p2']},
         'argument joined with group options'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b arg -- -c p1 -p2')),
-        {a: true, b: 'arg', c: false, _: ['-c', 'p1', '-p2']},
+        {a: 1, b: 'arg', c: 0, _: ['-c', 'p1', '-p2']},
         'everything after "--" there is operands'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-a -b "a r g" "p1 p2"')),
-        {a: true, b: 'a r g', c: false, _: ['p1 p2']},
+        {a: 1, b: 'a r g', c: 0, _: ['p1 p2']},
         'multiword operands and argument'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('-b -a')),
-        {a: false, b: '-a', c: false},
+        {a: 0, b: '-a', c: 0},
         'no optional arguments'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('"-a -b"')),
-        {a: false, b: '', c: false, _: ['-a -b']},
+        {a: 0, b: '', c: 0, _: ['-a -b']},
         'no multiword options'
     );
 
     t.deepEqual(
         oopt('ab:c', arrgv('p1 p2 -a -b arg')),
-        {a: false, b: '', c: false, _: ['p1', 'p2', '-a', '-b', 'arg']},
+        {a: 0, b: '', c: 0, _: ['p1', 'p2', '-a', '-b', 'arg']},
         'operands before options'
     );
 


### PR DESCRIPTION
Hi, I really like this module, thank you for making it!

I've added support for multiple invocations of the same option. I.e. using `cmd -vvv -q val1 -q val2`. I've separated it into two commits, one for options without arguments and one commit for options with arguments. Maybe you like it.